### PR TITLE
Add DXT packaging

### DIFF
--- a/.github/workflows/dxt-release.yml
+++ b/.github/workflows/dxt-release.yml
@@ -1,0 +1,21 @@
+name: Release DXT
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.node-version'
+      - run: npm install
+      - run: npm run build
+      - run: npx --yes @anthropic-ai/dxt pack -o todoist-mcp.dxt
+      - uses: softprops/action-gh-release@v1
+        with:
+          files: todoist-mcp.dxt

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .env
-build/
+server/
 node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ FROM node:22-alpine AS release
 WORKDIR /app
 
 # Copy the built files from the builder stage
-COPY --from=builder /app/build ./build
+COPY --from=builder /app/server ./server
 
 # Copy node_modules for runtime
 COPY --from=builder /app/node_modules ./node_modules
@@ -40,4 +40,4 @@ ENV NODE_ENV=production
 # EXPOSE 3000
 
 # Define the command to run the server
-CMD ["node", "build/index.js"]
+CMD ["node", "server/index.js"]

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Then, in your `claude_desktop_config.json`, add a new MCP server:
     "mcpServers": {
         "todoist-mcp": {
             "command": "node",
-            "args": ["/path/to/repo/build/index.js"],
+            "args": ["/path/to/repo/server/index.js"],
             "env": {
                 "TODOIST_API_KEY": "your_todoist_api_key"
             }

--- a/bin/index.js
+++ b/bin/index.js
@@ -1,2 +1,2 @@
 #!/usr/bin/env node
-import '../build/index.js';
+import '../server/index.js'

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,17 @@
+{
+    "name": "todoist-mcp",
+    "version": "1.0.2",
+    "description": "MCP server to interact with Todoist tasks and projects.",
+    "server": {
+        "command": "node",
+        "args": ["server/index.js"]
+    },
+    "config": {
+        "TODOIST_API_KEY": {
+            "label": "Todoist API Key",
+            "description": "API token used to authenticate with Todoist. Configure this via the Claude UI.",
+            "type": "string",
+            "secret": true
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "scripts": {
         "build": "npm run build-tsc && npm run permissions",
         "build-tsc": "npx tsc",
-        "permissions": "node -e \"require('fs').chmodSync('build/index.js', '755')\"",
+        "permissions": "node -e \"require('fs').chmodSync('server/index.js', '755')\"",
         "format": "biome check --write",
         "prepare": "husky || true && npm run build"
     },
@@ -37,6 +37,8 @@
         "typescript": "5.8.3"
     },
     "lint-staged": {
-        "*.{js,ts,json}": ["biome check --write"]
+        "*.{js,ts,json}": [
+            "biome check --write"
+        ]
     }
 }

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -14,4 +14,4 @@ startCommand:
   commandFunction:
     # A function that produces the CLI command to start the MCP on stdio.
     |-
-    config => ({command: 'node', args: ['build/index.js'], env: { TODOIST_API_KEY: config.todoistApiKey }})
+    config => ({command: 'node', args: ['server/index.js'], env: { TODOIST_API_KEY: config.todoistApiKey }})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
         "target": "ES2022",
         "module": "Node16",
         "moduleResolution": "Node16",
-        "outDir": "./build",
+        "outDir": "./server",
         "rootDir": "./src",
         "strict": true,
         "esModuleInterop": true,


### PR DESCRIPTION
## Summary
- add `manifest.json` describing MCP server for DXT
- change build output folder to `server` and update paths
- update Dockerfile, README and smithery config for new server path
- ignore generated `server/`
- add workflow to publish packaged DXT on tag releases

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685f329e429083278e1cb07cd40f5f65